### PR TITLE
Feature #14646 Отображение занятости

### DIFF
--- a/Sources/Timeline/Event.swift
+++ b/Sources/Timeline/Event.swift
@@ -3,6 +3,8 @@ import UIKit
 public final class Event: EventDescriptor {
   public var responseType: Int = 0
   public var isCancelledAppointment: Bool = false
+  public var isBaseCalendar: Bool = false
+  public var organizerStatus: Int = 0
     
   public var dateInterval = DateInterval()
   public var isAllDay = false

--- a/Sources/Timeline/EventDescriptor.swift
+++ b/Sources/Timeline/EventDescriptor.swift
@@ -16,6 +16,8 @@ public protocol EventDescriptor: AnyObject {
   var editedEvent: EventDescriptor? {get set}
   var responseType: Int { get }
   var isCancelledAppointment: Bool { get }
+  var isBaseCalendar: Bool { get }
+  var organizerStatus: Int { get }
   func makeEditable() -> Self
   func commitEditing()
 }


### PR DESCRIPTION
https://rdr.workspad.com/issues/14646

Обновление логики по покраске событий календаря в зависимости от того, базовый это календарь или импортированный. В импортированном покраска занятости.

Пример покраски событий импортированного календаря:
![IMG_2872](https://github.com/Workspad/CalendarKit/assets/75809668/85e42ed0-61dc-40d1-8645-7386a029321f)
![IMG_2871](https://github.com/Workspad/CalendarKit/assets/75809668/a7f9058f-4c22-4506-90d4-a0a6644b6b85)
