### PR TITLE
Bug #17347, Bug #17344

### DIFF
--- a/Sources/Timeline/AppointmentView.swift
+++ b/Sources/Timeline/AppointmentView.swift
@@ -143,7 +143,7 @@ open class AppointmentView: UIView {
         let attributedSubject = NSAttributedString(string: event.text, attributes: eventAttributes)
         attributedText.append(event.isCancelledAppointment ? cancelledSubject : attributedSubject)
         
-        if let location = event.location {
+        if let location = event.location, location != "" {
             let attributedLocation = NSAttributedString(string: location, attributes: locationAttributes)
             attributedText.append(separator)
             attributedText.append(attributedLocation)
@@ -529,8 +529,8 @@ extension UIColor {
     static var stactTextColor: UIColor = {
         return UIColor { (UITraitCollection: UITraitCollection) -> UIColor in
             if UITraitCollection.userInterfaceStyle == .dark {
-                /// Return the color for Dark Mode
-                return .label
+                /// Return the color for Dark Mode #C7E0F4
+                return UIColor(red: 199/255, green: 224/255, blue: 244/255, alpha: 1)
             } else {
                 /// Return the color for Light Mode #004578
                 return UIColor(red: 0/255, green: 69/255, blue: 120/255, alpha: 1)


### PR DESCRIPTION
**Bug #17347** В расшаренных календарях с полными правами цвет события зависит от занятости в дневном виде и 3 / 7 дней — обновила цвет текста события
https://rdr.workspad.com/issues/17347

**Bug #17344** В дневном виде отображается троеточие после занятости в событиях на весь день расшаренного календаря — добавила проверку, чтобы при пустом значении location не делался перенос строки
https://rdr.workspad.com/issues/17344