### PR TITLE
Bug #17347 В расшаренных календарях с полными правами цвет события зависит от занятости в дневном виде и 3 / 7 дней

### DIFF
--- a/Sources/Timeline/AppointmentView.swift
+++ b/Sources/Timeline/AppointmentView.swift
@@ -155,9 +155,11 @@ open class AppointmentView: UIView {
         descriptor = event
         
         setupViewStyle(with: CalendarResponse(rawValue: event.responseType),
-                            isCancelledAppointment: event.isCancelledAppointment,
-                            isBaseCalendar: event.isBaseCalendar,
-                            organizerStatus: event.organizerStatus)
+                       isCancelledAppointment: event.isCancelledAppointment,
+                       isBaseCalendar: event.isBaseCalendar,
+                       organizerStatus: event.organizerStatus,
+                       hasFullAccess: event.hasFullAccess
+        )
         
         pointView.backgroundColor = event.color
         
@@ -362,9 +364,11 @@ open class AppointmentView: UIView {
     private func setupViewStyle(with responseType: CalendarResponse?,
                                 isCancelledAppointment: Bool,
                                 isBaseCalendar: Bool,
-                                organizerStatus: Int) {
-        if isBaseCalendar {
-            /// Цвет события базового календаря зависит от статуса ответа на мероприятие
+                                organizerStatus: Int,
+                                hasFullAccess: Bool) {
+        /// Для базового календаря или расшаренного с полными правами (представитель, редактор, полные сведения)
+        if isBaseCalendar || (!isBaseCalendar && hasFullAccess) {
+            /// Цвет события зависит от статуса ответа на мероприятие
             backgroundColor = getColorForBaseCalendarEvent(responseType, isCancelledAppointment)
             color = isZeroDuration ? .clear : getColorForBaseCalendarEvent(responseType, isCancelledAppointment)
 
@@ -375,7 +379,8 @@ open class AppointmentView: UIView {
             
             stactTextLabel.textColor = responseType == .requestNotSent ? .appRed : .stactTextColor
         } else {
-            /// Цвет события импортированного календаря зависит из статуса занятости организатора
+            /// Для расшаренного календаря с краткими правами (краткие сведения, только доступность)
+            /// Цвет события зависит из статуса занятости организатора
             let status = OrganizerStatus(rawValue: organizerStatus) ?? .busy
             backgroundColor = getColorForImportedCalendarEvent(status)
             color = isZeroDuration ? .clear : getColorForImportedCalendarEvent(status)

--- a/Sources/Timeline/Event.swift
+++ b/Sources/Timeline/Event.swift
@@ -4,6 +4,7 @@ public final class Event: EventDescriptor {
   public var responseType: Int = 0
   public var isCancelledAppointment: Bool = false
   public var isBaseCalendar: Bool = false
+  public var hasFullAccess: Bool = false
   public var organizerStatus: Int = 0
     
   public var dateInterval = DateInterval()

--- a/Sources/Timeline/EventDescriptor.swift
+++ b/Sources/Timeline/EventDescriptor.swift
@@ -18,6 +18,7 @@ public protocol EventDescriptor: AnyObject {
   var isCancelledAppointment: Bool { get }
   var isBaseCalendar: Bool { get }
   var organizerStatus: Int { get }
+  var hasFullAccess: Bool { get }
   func makeEditable() -> Self
   func commitEditing()
 }


### PR DESCRIPTION
https://rdr.workspad.com/issues/17347

До этого изменения все расшаренные календари для покраски события смотрели на поле занятости организатора. Теперь дополнительно есть проверка прав расшаренного календаря — если есть доступ к данным, то красим событие исходя из статуса ответа на приглашение (принял, под вопросом...). Если прав нет, то исходя из занятости (занят, свободен...).